### PR TITLE
Add missing parenthesis in peft_utils.py

### DIFF
--- a/peft_utils.py
+++ b/peft_utils.py
@@ -81,7 +81,7 @@ class GPTQLoraLinear(torch.nn.Linear, LoraLayer):
             scale = self.scaling[self.active_adapter]
 
             x = x.type_as(lora_A.weight.data)
-            adapter_result = (lora_B(lora_A(lora_dropout(self.qa_pool(x))) * scale).type_as(result)
+            adapter_result = (lora_B(lora_A(lora_dropout(self.qa_pool(x))) * scale).type_as(result))
             result += adapter_result
         else:
             result = self.linear_module(x)


### PR DESCRIPTION
I followed your README instructions and got an error at this line when running `python qalora.py --help`.
With this fix I can run it.